### PR TITLE
Fix leaderboard caption to match top ten items

### DIFF
--- a/Actifit/Actifit/Controllers/DailyLeaderBoardBVC.swift
+++ b/Actifit/Actifit/Controllers/DailyLeaderBoardBVC.swift
@@ -113,7 +113,7 @@ extension DailyLeaderBoardBVC : UITableViewDataSource, UITableViewDelegate {
     //MARK: UITableViewDataSource
     
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return "Daily Leaderboard: Top 5"
+        return "Daily Leaderboard: Top 10"
     }
 }
 


### PR DESCRIPTION
I noticed the leaderboard is labeled "Top 5" but actually shows a list of  ten, as shown below. Changing the caption makes it  consistent. @mcfarhat @hitenkmr 

![leaderboard-caption - edited](https://user-images.githubusercontent.com/868675/46576716-f0658180-c99e-11e8-81f8-2e9b72acd4dc.png)



